### PR TITLE
Fix premake to apply Linux settings to all gmake's

### DIFF
--- a/Build/MakeGMakeProjects.sh
+++ b/Build/MakeGMakeProjects.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+premake5 gmake2

--- a/Build/premake5.lua
+++ b/Build/premake5.lua
@@ -32,7 +32,7 @@ workspace ("Tilted Core")
     filter { "action:vs*"}
         buildoptions { "/wd4512", "/wd4996", "/wd4018", "/Zm500" }
         
-    filter { "action:gmake2", "language:C++" }
+    filter { "action:gmake*", "language:C++" }
         buildoptions { "-g -fpermissive" }
         linkoptions ("-lm -lpthread -pthread -Wl,--no-as-needed -lrt -g -fPIC")
             

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PROJECTS := Core Tests
+FORWARDED := clean help ${PROJECTS}
+
+ifeq ($(shell uname -m),x86_64)
+	platform := x64
+else
+	platform := x32
+endif
+
+config := debug
+premake_config = ${config}_${platform}
+
+.PHONY: all tests $(FORWARDED)
+
+all: Build/projects
+	$(MAKE) -C Build/projects all config=${premake_config}
+
+tests: all
+	Build/lib/${platform}/Tests
+
+Build/projects:
+	cd Build && ./MakeGMakeProjects.sh
+
+$(PROJECTS): Build/projects
+	$(MAKE) -C Build/projects $@ config=${premake_config}
+


### PR DESCRIPTION
Both `gmake` and `gmake2` needs these options after all.