### PR TITLE
Add explicit std::hash implementation for String

### DIFF
--- a/Code/core/include/Stl.hpp
+++ b/Code/core/include/Stl.hpp
@@ -52,3 +52,16 @@ namespace TiltedPhoques
         return std::allocate_shared<T>(StlAllocator<T>(), std::forward<Args>(args)...);
     }
 }
+
+namespace std
+{
+    template<> struct hash<TiltedPhoques::String>
+    {
+        typedef TiltedPhoques::String argument_type;
+        typedef std::size_t result_type;
+        result_type operator()(argument_type const& s) const noexcept
+        {
+            return std::hash<std::string>{}(s.data());
+        }
+    };
+}

--- a/Code/core/include/Stl.hpp
+++ b/Code/core/include/Stl.hpp
@@ -57,11 +57,9 @@ namespace std
 {
     template<> struct hash<TiltedPhoques::String>
     {
-        typedef TiltedPhoques::String argument_type;
-        typedef std::size_t result_type;
-        result_type operator()(argument_type const& s) const noexcept
+        std::size_t operator()(const TiltedPhoques::String& aString) const noexcept
         {
-            return std::hash<std::string>{}(s.data());
+            return std::hash<std::string>{}(aString.data());
         }
     };
 }


### PR DESCRIPTION
As the `String` type uses a different allocator than the regular `std::string` type, the `std::hash<std::string>` implementation is technically not valid to use for hashing the String type.

What this means is that the `String` won't be usable in a `std::unordered_map` - or other hash-based structure - on most compilers.